### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nodecross/maintainer


### PR DESCRIPTION
## Why

To maintain the source code and branch protect with this code owner GitHub team.