### PR TITLE
feat: add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Why

To manage the dependencies.

It is hard to track all the dependencies' updates and update this project by ourselves. Let's automate it 🚀 

## Ref

*  [Keep all your packages up to date with Dependabot, GitHub / Blog](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)