### PR TITLE
Remove i686 install docs and fix x86_64 install command

### DIFF
--- a/source/installation/10-install-on-linux-i686.md
+++ b/source/installation/10-install-on-linux-i686.md
@@ -1,9 +1,0 @@
-# Install on Linux (i686)
-
-NodeX officially provides pre-built binaries for the i686 architecture Linux.
-
-```bash
-% curl https://github.com/nodecross/nodex/tags/v1.0.0/assets/nodex.i686.zip
-% unzip nodex.i686.zip
-% install nodex.i686/nodex
-```

--- a/source/installation/20-install-on-linux-x86-64.md
+++ b/source/installation/20-install-on-linux-x86-64.md
@@ -4,6 +4,6 @@ NodeX officially provides pre-built binaries for the x86_64 architecture Linux.
 
 ```bash
 % curl -OL https://github.com/nodecross/nodex/releases/latest/download/nodex-agent-x86_64.zip
-% unzip nodex.x86_64.zip
-% install nodex.x86_64/nodex
+% unzip nodex-agent-x86_64.zip
+% install nodex-agent
 ```

--- a/source/installation/20-install-on-linux-x86-64.md
+++ b/source/installation/20-install-on-linux-x86-64.md
@@ -3,7 +3,7 @@
 NodeX officially provides pre-built binaries for the x86_64 architecture Linux.
 
 ```bash
-% curl https://github.com/nodecross/nodex/tags/v1.0.0/assets/nodex.x86_64.zip
+% curl -OL https://github.com/nodecross/nodex/releases/latest/download/nodex-agent-x86_64.zip
 % unzip nodex.x86_64.zip
 % install nodex.x86_64/nodex
 ```


### PR DESCRIPTION
## Description

- The installation documentation for i686 has been removed because Nodex Agent does not build binaries for the i686 architecture.
- The commands in the installation documentation for x86_64 were incorrect and have been corrected.