### PR TITLE
chore: Remove i686 related wording

### DIFF
--- a/source/installation/00-overview.md
+++ b/source/installation/00-overview.md
@@ -2,7 +2,6 @@
 
 Currently, NodeX officially offers the following types of pre-built binaries.
 
-- Linux OS (i686)
 - Linux OS (x86_64)
 
 The NodeX agent is currently available as a pre-built binary download from the release page in the GitHub repository. In the future, we are working on making it easier for developers to install the agent by using the distribution's official package management system to provide a better installation and development experience.

--- a/source/installation/index.md
+++ b/source/installation/index.md
@@ -1,6 +1,6 @@
 # Installation
 
-This section describes how to install NodeX. As we have explained, NodeX consists of NodeX Hub/Studio, a service for administrators, and NodeX AGENT, which is installed on edge devices. No special procedures are required to start using NodeX Hub/Studio, and a single email address is all you need to start your trial right away. NodeX AGENT, on the other hand, must be embedded in an edge device and is now available in executable binaries for the i686 and x86_64 architectures of the Linux OS. NodeX AGENT consists of a single binary with no dependencies and can be easily installed.
+This section describes how to install NodeX. As we have explained, NodeX consists of NodeX Hub/Studio, a service for administrators, and NodeX AGENT, which is installed on edge devices. No special procedures are required to start using NodeX Hub/Studio, and a single email address is all you need to start your trial right away. NodeX AGENT, on the other hand, must be embedded in an edge device and is now available in executable binaries for the x86_64 architectures of the Linux OS. NodeX AGENT consists of a single binary with no dependencies and can be easily installed.
 
 ```{note}
 You can register to NodeX Hub/Studio at [https://studio.nodecross.io](https://studio.nodecross.io) (under development).


### PR DESCRIPTION
# Why 
- Because the i686-related wording was still in place