### PR TITLE
Fix the broken example code to the `cli` commands and use permanent link

### DIFF
--- a/source/getting-started/index.md
+++ b/source/getting-started/index.md
@@ -85,7 +85,7 @@ $ cd /path/to/nodex
 $ cargo run
 ```
 
-3. Run receive message example. The original code is **[here](https://github.com/nodecross/nodex/blob/develop/examples/nodejs/src/receive.ts)**.
+3. Run receive message example. The original code is **[here](https://github.com/nodecross/nodex/tree/9bbcf0f6bcb6d0b487df7ed8368e347612053f27/examples/nodejs/cli)**.
 
 The following is part of the example code.
 


### PR DESCRIPTION
## Why

Because the directory name was renamed to https://github.com/nodecross/nodex/pull/198.

And we should always use the permanent link as we want to avoid showing 404 page on NodeX changes.