### PR TITLE
chore: fix release badge url

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -8,7 +8,7 @@
 <h1 style="text-align: center;">
 NodeX
     
-[![Release Pipeline](https://github.com/nodecross/nodex-agent/actions/workflows/release-pipeline.yml/badge.svg?branch=main)](https://github.com/nodecross/nodex-agent/actions/workflows/release-pipeline.yml) [![Coverage Status](https://coveralls.io/repos/github/nodecross/nodex-agent/badge.svg)](https://coveralls.io/github/nodecross/nodex-agent) [![Semantic Release](https://img.shields.io/badge/semantic--release-rust-B7410E?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
+[![Release Pipeline](https://github.com/nodecross/nodex-agent/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/nodecross/nodex-agent/actions/workflows/release.yml) [![Coverage Status](https://coveralls.io/repos/github/nodecross/nodex-agent/badge.svg)](https://coveralls.io/github/nodecross/nodex-agent) [![Semantic Release](https://img.shields.io/badge/semantic--release-rust-B7410E?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 </h1>
 
 <hr />


### PR DESCRIPTION
Why
The previous URL resulted in a not found error due to changes in the pipeline.

What
update release badge url

Rendered the .md on local.
![スクリーンショット 2024-02-21 21 15 38](https://github.com/nodecross/nodex-docs/assets/28969620/e1793de8-72b3-40c1-b65c-c75038644d62)
