### PR TITLE
fix: header format

### DIFF
--- a/source/concepts/30-message-sequence.md
+++ b/source/concepts/30-message-sequence.md
@@ -1,4 +1,4 @@
-## Message Sequence
+# Message Sequence
 
 This section describes the overall message flow when using the NodeX agent.
 
@@ -7,7 +7,7 @@ There are two possible message flows when using the NodeX agent.
 1. Verifiable Message
 2. E2E Encrypted (VM)
 
-#### Verifiable Message
+## Verifiable Message
 
 NodeX Agent sends and receives verifiable messages between devices.
 Below is a sequence diagram of the message from transmission to reception.
@@ -40,7 +40,7 @@ sequenceDiagram
 ```
 
 
-#### E2E Encrypted (VM)
+## E2E Encrypted (VM)
 
 NodeX Agent sends and receives E2E Ecrypted verifiable messages between devices.
 Below is a sequence diagram of the message from transmission to reception.


### PR DESCRIPTION
Due to a build error in Sphinx, the documentation was not updated to the latest version.
The build error was caused by a warning in the header formatting.
This has been fixed.

```
/home/runner/work/nodex-docs/nodex-docs/source/concepts/30-message-sequence.md:1: WARNING: Document headings start at H2, not H1 [myst.header]
/home/runner/work/nodex-docs/nodex-docs/source/concepts/30-message-sequence.md:10: WARNING: Non-consecutive header level increase; H2 to H4 [myst.header]
/home/runner/work/nodex-docs/nodex-docs/source/concepts/30-message-sequence.md:43: WARNING: Non-consecutive header level increase; H2 to H4 [myst.header]
```